### PR TITLE
Refactor 'is.integer'

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Checks _if_ a given value _is_ an integer.
 
 ```js
 is.integer(12); // true
+is.integer(10.0); // true
 is.integer(3.14); // false
 is.integer(Number.MIN_VALUE); // false
 is.integer(Infinity); // false

--- a/src/is/arithmetic.js
+++ b/src/is/arithmetic.js
@@ -26,6 +26,7 @@ export function isOdd(value) {
  * @returns {Boolean} `true` if the value is an integer; otherwise, `false`
  */
 export function isInteger(value) {
+    if (Number.isInteger) return Number.isInteger(value);
     if (!isNumber(value)) return false;
     return value % 1 === 0;
 }

--- a/test/is/arithmetic.test.js
+++ b/test/is/arithmetic.test.js
@@ -26,16 +26,26 @@ describe('isOdd', () => {
 });
 
 describe('isInteger', () => {
-    test('returns true on integers', () => {
-        expect(is.integer(12)).toBeTruthy();
+    function testIsInteger() {
+        test('returns true on integers', () => {
+            expect(is.integer(12)).toBeTruthy();
+            expect(is.integer(10.0)).toBeTruthy();
+        });
+        test('returns false on others', () => {
+            expect(is.integer(3.14)).toBeFalsy();
+            expect(is.integer(Number.MIN_VALUE)).toBeFalsy();
+            expect(is.integer(Infinity)).toBeFalsy();
+            expect(is.integer('6')).toBeFalsy();
+        });
+        testFalsyWithNullable(is.integer);
+    }
+    describe('Number.isInteger exists', () => {
+        testIsInteger();
     });
-    test('returns false on others', () => {
-        expect(is.integer(3.14)).toBeFalsy();
-        expect(is.integer(Number.MIN_VALUE)).toBeFalsy();
-        expect(is.integer(Infinity)).toBeFalsy();
-        expect(is.integer('6')).toBeFalsy();
-    });
-    testFalsyWithNullable(is.integer);
+    describe('Number.isInteger does not exist', () => {
+        Number.isNaN = null;
+        testIsInteger();
+    })
 });
 
 describe('aliases', () => {


### PR DESCRIPTION
fixes #50 

@boristane  `Math.round` showed small to no improvement in terms of performance. 

Here are the results, in seconds, for 100'000'000 calls

%1 === 0 | Math.round
--- | ---
2,467 | 2,427
2,078 | 2,118
2,786 | 2,112
2,343 | 2,316
2,132 | 2,09
--- | ---
2,361 | 2,213
